### PR TITLE
feat: use newer appium doctor

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "prettier": "prettier 'src/**/*.ts' --write --single-quote"
   },
   "dependencies": {
+    "@appium/doctor": "^2.0.14",
     "@inquirer/checkbox": "^0.0.30-alpha.0",
     "@nightwatch/mobile-helper": "^0.1.12",
     "appium-adb": "^9.10.24",
-    "appium-doctor": "^1.16.2",
     "chalk": "^4.1.2",
     "inquirer": "^8.2.4",
     "inquirer-fuzzy-path": "^2.3.0",


### PR DESCRIPTION
Appium doctor should use proper newer one -> https://www.npmjs.com/package/@appium/doctor

```
? Select an option Run Appium Doctor
? platform: android
WARN AppiumDoctor [Deprecated] Please use appium-doctor installed with "npm install @appium/doctor --location=global"
info AppiumDoctor Appium Doctor v.1.16.2
info AppiumDoctor ### Diagnostic for necessary dependencies starting ###
info AppiumDoctor  ✔ The Node.js binary was found at: /Users/kazu/.nvm/versions/node/v16.15.1/bin/node
info AppiumDoctor  ✔ Node version is 16.15.1
```

`appium-doctor` command itself is the same.